### PR TITLE
Add option to remove toast HTML from document after dismissal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /.idea
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ this.props = {
     delay: 5000, //	delay in milliseconds before hiding the toast, set delay to `Infinity` to make it sticky
     position: "top-0 end-0", // top right
     direction: "append", // or "prepend", the stack direction
-    ariaLive: "assertive"
+    ariaLive: "assertive",
+    destroyOnClose: false // set to true to remove HTML from the DOM after dismissal
 }
 ```
 

--- a/index.html
+++ b/index.html
@@ -42,19 +42,26 @@
     import "./src/bootstrap-show-toast.js"
 
     document.getElementById("button-show-simple").addEventListener("click", function () {
-        bootstrap.showToast({body: "Hello Toast!"})
+        bootstrap.showToast({
+            body: "Hello Toast!",
+            destroyOnClose: true
+        })
     })
     document.getElementById("button-show-info").addEventListener("click", function () {
         const toast = bootstrap.showToast({
             header: "Information",
             headerSmall: "just now",
             body: "<p>This notification has a headline and more text than the previous one.</p><div><button class='btn btn-primary me-1 btn-sm'>Click me</button><button class='btn btn-secondary btn-sm' data-bs-dismiss='toast'>Close</button></div>",
-            delay: 20000
+            delay: 20000,
+            destroyOnClose: true
         })
         toast.element.querySelector(".btn-primary").addEventListener("click", () => {
             bootstrap.showToast({
-                body: "Thank you for clicking", direction: "append",
-                toastClass: "text-bg-success", closeButtonClass: "btn-close-white"
+                body: "Thank you for clicking",
+                direction: "append",
+                toastClass: "text-bg-success",
+                closeButtonClass: "btn-close-white",
+                destroyOnClose: true
             })
         })
     })
@@ -62,12 +69,17 @@
         bootstrap.showToast({
             header: "Alert",
             body: "Red Alert!",
-            toastClass: "text-bg-danger"
+            toastClass: "text-bg-danger",
+            destroyOnClose: true
         })
     })
     document.getElementById("button-show-sticky").addEventListener("click", function () {
         bootstrap.showToast({
-            body: "This notification will stay", toastClass: "text-bg-secondary", closeButtonClass: "btn-close-white", delay: Infinity
+            body: "This notification will stay",
+            toastClass: "text-bg-secondary",
+            closeButtonClass: "btn-close-white",
+            delay: Infinity,
+            destroyOnClose: true
         })
     })
 </script>

--- a/src/bootstrap-show-toast.js
+++ b/src/bootstrap-show-toast.js
@@ -79,8 +79,10 @@
             animation: this.props.animation,
             autohide: this.props.delay > 0 && this.props.delay !== Infinity, // TODO remove 0 for infinity 2022-09-02
             delay: this.props.delay
-
         })
+        if (this.props.destroyOnClose) {
+            toastElement.addEventListener('hidden.bs.toast', toastElement.remove)
+        }
         this.toast.show()
 
         return toastElement


### PR DESCRIPTION
A current feature gap between this dynamic toast generation plugin and other standalone JavaScript toast libraries is that unlike those other libraries this plugin does not remove the HTML for a toast after it has been dismissed/closed. As a result, the DOM will be cluttered with dismissed toasts that will never be shown again, which in use cases where someone is on a page generating toasts for an extended session could potentially bog down the UX. This change adds an opt-in feature to have the HTML for a toast removed from the DOM when it is dismissed, using the `hidden.bs.toast` event [as documented by Bootstrap](https://getbootstrap.com/docs/5.3/components/toasts/#events).