### PR TITLE
container id fix

### DIFF
--- a/src/bootstrap-show-toast.js
+++ b/src/bootstrap-show-toast.js
@@ -28,10 +28,10 @@
             direction: "append", // or "prepend", the stack direction
             ariaLive: "assertive" // the "aria-live" attribute, for accessibility
         }
-        this.containerId = "bootstrap-show-toast-container-" + this.props.position.replace(" ", "_")
         for (let prop in props) {
             this.props[prop] = props[prop]
         }
+        this.containerId = "bootstrap-show-toast-container-" + this.props.position.replace(" ", "_")
         const cssClass = ("toast " + this.props.toastClass).trim()
         let toastHeader = ""
         const showHeader = this.props.header || this.props.headerSmall

--- a/src/bootstrap-show-toast.js
+++ b/src/bootstrap-show-toast.js
@@ -31,7 +31,7 @@
         for (let prop in props) {
             this.props[prop] = props[prop]
         }
-        this.containerId = "bootstrap-show-toast-container-" + this.props.position.replace(" ", "_")
+        this.containerId = "bootstrap-show-toast-container-" + this.props.position.replaceAll(" ", "_")
         const cssClass = ("toast " + this.props.toastClass).trim()
         let toastHeader = ""
         const showHeader = this.props.header || this.props.headerSmall


### PR DESCRIPTION
The default value overwritten the `containerId` instead of the other way around. Also, I replaced `this.props.position.replace(" ", "_")` with `this.props.position.replaceAll(" ", "_")`.

`bottom-0 end-0 p-3` would produce `bootstrap-show-toast-container-bottom-0_end-0 p-3`